### PR TITLE
Fixed fuel percentage.

### DIFF
--- a/drmon.lua
+++ b/drmon.lua
@@ -238,7 +238,7 @@ function update()
 
     local fuelPercent, fuelColor
 
-    fuelPercent = 100 - math.ceil(ri.fuelConversion / ri.maxFuelConversion * 100)*.01
+    fuelPercent = 100 - math.ceil(ri.fuelConversion / ri.maxFuelConversion * 100)
 
     fuelColor = colors.red
 

--- a/drmon.lua
+++ b/drmon.lua
@@ -238,7 +238,7 @@ function update()
 
     local fuelPercent, fuelColor
 
-    fuelPercent = 100 - math.ceil(ri.fuelConversion / ri.maxFuelConversion * 100)
+    fuelPercent = 100 - math.ceil(ri.fuelConversion / ri.maxFuelConversion * 10000)*.01
 
     fuelColor = colors.red
 


### PR DESCRIPTION
Before it did percents of percents.

I noticed that the fuel percentage was wrong because you had the percentage calculated on line 241 with the Math.ceil() function was being converted into a percentage and then back to a decimal. I fixed it.